### PR TITLE
composer: bump PHP version to 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": ">= 5.6",
+    "php": ">= 7.0",
     "tracy/tracy": "~2.4.15 || ~2.5.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": ">= 7.0",
+    "php": ">= 7.1",
     "tracy/tracy": "~2.4.15 || ~2.5.0"
   },
   "require-dev": {


### PR DESCRIPTION
Because `\Throwable` has been introduced in PHP 7.0 and there is no real reason for supporting PHP 5.6.