### PR TITLE
New version

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -163,10 +163,10 @@ This extension requires to have sentry installed.
 composer require sentry/sentry
 ```
 
-Now you should register new company/profile at Sentry's page (https://sentry.io/organizations/new/). There you 
-obtained key, secret and project ID. Put these variables into neon file.
+Now you should go to project Settings page -> Client Keys (DSN) section. 
+There you obtained DNS url. Put the url into neon file.
 
 ```yaml
 sentry:
-    url: https://<key>:<secret>@sentry.io/<project>
+    url: https://<key>@sentry.io/<project>
 ```

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -26,7 +26,7 @@ Basically, it overrides Tracy's default logger by our universal, pluggable logge
 
 ### Default loggers
 
-There are 2 types of loggers defined by default.
+There are 3 types of loggers defined by default.
 
 - **FileLogger** - creates <priority>.log file
 - **BlueScreenFileLogger** - creates exception-*.html
@@ -67,7 +67,7 @@ class MyDatabaseLogger implements ILogger
      * @param mixed $message
      * @return void
      */
-    public function log($message, string $priority = self::INFO)
+    public function log($message, string $priority = self::INFO): void
     {
         // store exception to database...
     }

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -28,7 +28,7 @@ Basically, it overrides Tracy's default logger by our universal, pluggable logge
 
 There are 2 types of loggers defined by default.
 
-- **ExceptionFileLogger** - creates exception.log file
+- **FileLogger** - creates <priority>.log file
 - **BlueScreenFileLogger** - creates exception-*.html
 - **SendMailLogger** - sends exception to email
 
@@ -37,7 +37,7 @@ You can redefine these loggers in `logging.loggers`.
 ```yaml
 logging:
     loggers: 
-        - Contributte\Logging\ExceptionFileLogger(%logDir%)
+        - Contributte\Logging\FileLogger(%logDir%)
         - Contributte\Logging\BlueScreenFileLogger(%logDir%)
         - Contributte\Logging\SendMailLogger(
             Contributte\Logging\Mailer\TracyMailer(
@@ -65,10 +65,9 @@ class MyDatabaseLogger implements ILogger
 
     /**
      * @param mixed $message
-     * @param string $priority
      * @return void
      */
-    public function log($message, $priority = self::INFO)
+    public function log($message, string $priority = self::INFO)
     {
         // store exception to database...
     }

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,5 @@
 /composer.lock
 
 # Tests
-/tests/tmp
-/tests/coverage.html
-
-# Temporary
 /temp
+/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,65 +1,65 @@
 language: php
 php:
-  - 7.1
-  - 7.2
-  - 7.3
+- 7.1
+- 7.2
+- 7.3
 
 before_install:
 # Turn off XDebug
 - phpenv config-rm xdebug.ini || return 0
 
 install:
-  # Composer
-  - travis_retry composer install --no-progress --prefer-dist
+# Composer
+- travis_retry composer install --no-progress --prefer-dist
 
 script:
-  # Check all dependencies at master are up-to-date when running regular builds
-  - |
-    if [[ $TRAVIS_EVENT_TYPE == "cron" && $TRAVIS_BRANCH == "master" ]]; then
-        composer outdated --direct --strict
-    fi
-
-  # Tests
-  - composer run-script tests
+# Tests
+- composer run-script tests
 
 after_failure:
-  # Print *.actual content
-  - for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
+# Print *.actual content
+- for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
 
 jobs:
-  include:
+    include:
     - env: title="Lowest Dependencies 7.1"
       php: 7.1
       install:
-        - travis_retry composer update --no-progress --prefer-dist --prefer-lowest
+      - travis_retry composer update --no-progress --prefer-dist --prefer-lowest
       script:
-        - composer run-script tests
+      - composer run-script tests
 
     - stage: Quality Assurance
       php: 7.1
       script:
-        - composer run-script qa
+      - composer run-script qa
 
     - stage: Phpstan
       php: 7.1
       script:
-        - composer run-script phpstan-install
-        - composer run-script phpstan
+      - composer run-script phpstan-install
+      - composer run-script phpstan
 
     - stage: Test Coverage
       if: branch = master AND type = push
       php: 7.1
       script:
-        - composer run-script coverage
+      - composer run-script coverage
       after_script:
-        - wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar
-        - php php-coveralls.phar --verbose --config tests/.coveralls.yml
+      - wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar
+      - php php-coveralls.phar --verbose --config tests/.coveralls.yml
 
-  allow_failures:
+    - stage: Outdated Dependencies
+      if: branch = master AND type = cron
+      php: 7.1
+      script:
+      - composer outdated --direct --strict
+
+    allow_failures:
     - stage: Test Coverage
 
 sudo: false
 
 cache:
-  directories:
+    directories:
     - $HOME/.composer/cache

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![Build Status](https://img.shields.io/travis/contributte/logging.svg?style=flat-square)](https://travis-ci.org/contributte/logging)
 [![Code coverage](https://img.shields.io/coveralls/contributte/logging.svg?style=flat-square)](https://coveralls.io/r/contributte/logging)
 [![Licence](https://img.shields.io/packagist/l/contributte/logging.svg?style=flat-square)](https://packagist.org/packages/contributte/logging)
-
 [![Downloads this Month](https://img.shields.io/packagist/dm/contributte/logging.svg?style=flat-square)](https://packagist.org/packages/contributte/logging)
 [![Downloads total](https://img.shields.io/packagist/dt/contributte/logging.svg?style=flat-square)](https://packagist.org/packages/contributte/logging)
 [![Latest stable](https://img.shields.io/packagist/v/contributte/logging.svg?style=flat-square)](https://packagist.org/packages/contributte/logging)
+[![PHPStan](https://img.shields.io/badge/PHPStan-enabled-brightgreen.svg?style=flat)](https://github.com/phpstan/phpstan)
 
 ## Discussion / Help
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">= 7.1",
-    "tracy/tracy": "~2.4.15 || ~2.5.0"
+    "tracy/tracy": "~2.5.5"
   },
   "require-dev": {
     "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
       "mkdir -p temp/phpstan",
       "composer require -d temp/phpstan phpstan/phpstan:^0.10",
       "composer require -d temp/phpstan phpstan/phpstan-deprecation-rules:^0.10",
-      "composer require -d temp/phpstan phpstan/phpstan-nette:^0.10"
+      "composer require -d temp/phpstan phpstan/phpstan-nette:^0.10",
+      "composer require -d temp/phpstan phpstan/phpstan-strict-rules:^0.10"
     ],
     "phpstan": [
       "temp/phpstan/vendor/bin/phpstan analyse -l max -c phpstan.neon src"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,9 +2,4 @@ includes:
 	- temp/phpstan/vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- temp/phpstan/vendor/phpstan/phpstan-nette/extension.neon
 	- temp/phpstan/vendor/phpstan/phpstan-nette/rules.neon
-
-parameters:
-	ignoreErrors:
-		- "#Binary operation \"\\+\" between int\\|false and int\\|string results in an error\\.#"
-		- "#Binary operation \"\\.\" between 'PHP: An error…' and array\\|string\\|null results in an error\\.#"
-		- "#Binary operation \"\\.\" between 'noreply@' and array\\|string\\|null results in an error\\.#"
+	- temp/phpstan/vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/AbstractLogger.php
+++ b/src/AbstractLogger.php
@@ -50,7 +50,7 @@ abstract class AbstractLogger implements ILogger
 			if ($file->isDot()) {
 				continue;
 			}
-			if (strpos($file->getBasename(), $hash)) {
+			if ((bool) strpos($file->getBasename(), $hash)) {
 				return $file->getPathname();
 			}
 		}

--- a/src/BlueScreenFileLogger.php
+++ b/src/BlueScreenFileLogger.php
@@ -20,7 +20,7 @@ class BlueScreenFileLogger extends AbstractLogger implements ILogger
 	/** @var BlueScreen|null */
 	private $blueScreen;
 
-	public function __construct(string $directory, ?BlueScreen $blueScreen = NULL)
+	public function __construct(string $directory, ?BlueScreen $blueScreen = null)
 	{
 		parent::__construct($directory);
 		$this->blueScreen = $blueScreen;

--- a/src/BlueScreenFileLogger.php
+++ b/src/BlueScreenFileLogger.php
@@ -20,17 +20,16 @@ class BlueScreenFileLogger extends AbstractLogger implements ILogger
 	/** @var BlueScreen|null */
 	private $blueScreen;
 
-	public function __construct(string $directory, ?BlueScreen $blueScreen = null)
+	public function __construct(string $directory, ?BlueScreen $blueScreen = NULL)
 	{
 		parent::__construct($directory);
 		$this->blueScreen = $blueScreen;
 	}
 
 	/**
-	 * @param string|Throwable $message
-	 * @param string $priority
+	 * @param mixed $message
 	 */
-	public function log($message, $priority): void
+	public function log($message, string $priority = ILogger::INFO): void
 	{
 		if (!is_dir($this->directory)) {
 			throw new InvalidStateException('Directory ' . $this->directory . ' is not found or is not directory.');

--- a/src/DI/TracyLoggingExtension.php
+++ b/src/DI/TracyLoggingExtension.php
@@ -3,7 +3,7 @@
 namespace Contributte\Logging\DI;
 
 use Contributte\Logging\BlueScreenFileLogger;
-use Contributte\Logging\ExceptionFileLogger;
+use Contributte\Logging\FileLogger;
 use Contributte\Logging\UniversalLogger;
 use Nette\DI\Compiler;
 use Nette\DI\CompilerExtension;
@@ -38,7 +38,7 @@ final class TracyLoggingExtension extends CompilerExtension
 
 		if ($config['loggers'] === null) {
 			$exceptionFileLogger = $builder->addDefinition($this->prefix('logger.exceptionfilelogger'))
-				->setFactory(ExceptionFileLogger::class, [$config['logDir']])
+				->setFactory(FileLogger::class, [$config['logDir']])
 				->setAutowired('self');
 
 			$blueScreenFileLogger = $builder->addDefinition($this->prefix('logger.bluescreenfilelogger'))

--- a/src/DI/TracyLoggingExtension.php
+++ b/src/DI/TracyLoggingExtension.php
@@ -36,6 +36,11 @@ final class TracyLoggingExtension extends CompilerExtension
 		$logger = $builder->addDefinition($this->prefix('logger'))
 			->setType(UniversalLogger::class);
 
+		if ($builder->hasDefinition('tracy.logger')) {
+			$builder->addDefinition($this->prefix('originalLogger'), $builder->getDefinition('tracy.logger'))
+				->setAutowired(false);
+		}
+
 		if ($config['loggers'] === null) {
 			$fileLogger = $builder->addDefinition($this->prefix('logger.filelogger'))
 				->setFactory(FileLogger::class, [$config['logDir']])

--- a/src/DI/TracyLoggingExtension.php
+++ b/src/DI/TracyLoggingExtension.php
@@ -37,7 +37,7 @@ final class TracyLoggingExtension extends CompilerExtension
 			->setType(UniversalLogger::class);
 
 		if ($config['loggers'] === null) {
-			$exceptionFileLogger = $builder->addDefinition($this->prefix('logger.exceptionfilelogger'))
+			$fileLogger = $builder->addDefinition($this->prefix('logger.filelogger'))
 				->setFactory(FileLogger::class, [$config['logDir']])
 				->setAutowired('self');
 
@@ -45,7 +45,7 @@ final class TracyLoggingExtension extends CompilerExtension
 				->setFactory(BlueScreenFileLogger::class, [$config['logDir']])
 				->setAutowired('self');
 
-			$logger->addSetup('addLogger', [$exceptionFileLogger]);
+			$logger->addSetup('addLogger', [$fileLogger]);
 			$logger->addSetup('addLogger', [$blueScreenFileLogger]);
 		}
 	}

--- a/src/ExceptionFileLogger.php
+++ b/src/ExceptionFileLogger.php
@@ -3,8 +3,8 @@
 namespace Contributte\Logging;
 
 use Contributte\Logging\Exceptions\Logical\InvalidStateException;
-use Contributte\Logging\Utils\Utils;
 use Exception;
+use Tracy\Logger;
 
 /**
  * ExceptionFileLogger based on official Tracy\Logger (@copyright David Grudl)
@@ -26,8 +26,8 @@ class ExceptionFileLogger extends AbstractLogger implements ILogger
 			throw new InvalidStateException('Directory "' . $this->directory . '" is not found or is not directory.');
 		}
 
-		$exceptionFile = ($message instanceof Exception) ? $this->getExceptionFile($message) : null;
-		$line = Utils::formatLogLine($message, $exceptionFile);
+		$exceptionFile = ($message instanceof Exception) ? $this->getExceptionFile($message) : NULL;
+		$line = Logger::formatLogLine($message, $exceptionFile);
 		$file = $this->directory . '/' . strtolower($priority) . '.log';
 
 		if (!@file_put_contents($file, $line . PHP_EOL, FILE_APPEND | LOCK_EX)) {

--- a/src/FileLogger.php
+++ b/src/FileLogger.php
@@ -25,11 +25,11 @@ class FileLogger extends AbstractLogger implements ILogger
 			throw new InvalidStateException('Directory "' . $this->directory . '" is not found or is not directory.');
 		}
 
-		$exceptionFile = ($message instanceof Throwable) ? $this->getExceptionFile($message) : NULL;
+		$exceptionFile = ($message instanceof Throwable) ? $this->getExceptionFile($message) : null;
 		$line = Logger::formatLogLine($message, $exceptionFile);
 		$file = $this->directory . '/' . strtolower($priority) . '.log';
 
-		if (!@file_put_contents($file, $line . PHP_EOL, FILE_APPEND | LOCK_EX)) {
+		if (!(bool) @file_put_contents($file, $line . PHP_EOL, FILE_APPEND | LOCK_EX)) {
 			throw new InvalidStateException('Unable to write to log file "' . $file . '". Is directory writable?');
 		}
 	}

--- a/src/FileLogger.php
+++ b/src/FileLogger.php
@@ -3,30 +3,29 @@
 namespace Contributte\Logging;
 
 use Contributte\Logging\Exceptions\Logical\InvalidStateException;
-use Exception;
+use Throwable;
 use Tracy\Logger;
 
 /**
  * ExceptionFileLogger based on official Tracy\Logger (@copyright David Grudl)
  *
- * Log all exceptions to exception.log
+ * Log all exceptions to <priority>.log
  *
  * @author Milan Felix Sulc <sulcmil@gmail.com>
  */
-class ExceptionFileLogger extends AbstractLogger implements ILogger
+class FileLogger extends AbstractLogger implements ILogger
 {
 
 	/**
-	 * @param string|Exception $message
-	 * @param string $priority
+	 * @param mixed $message
 	 */
-	public function log($message, $priority): void
+	public function log($message, string $priority = ILogger::INFO): void
 	{
 		if (!is_dir($this->directory)) {
 			throw new InvalidStateException('Directory "' . $this->directory . '" is not found or is not directory.');
 		}
 
-		$exceptionFile = ($message instanceof Exception) ? $this->getExceptionFile($message) : NULL;
+		$exceptionFile = ($message instanceof Throwable) ? $this->getExceptionFile($message) : NULL;
 		$line = Logger::formatLogLine($message, $exceptionFile);
 		$file = $this->directory . '/' . strtolower($priority) . '.log';
 

--- a/src/FileLogger.php
+++ b/src/FileLogger.php
@@ -7,9 +7,9 @@ use Throwable;
 use Tracy\Logger;
 
 /**
- * ExceptionFileLogger based on official Tracy\Logger (@copyright David Grudl)
+ * FileLogger based on official Tracy\Logger (@copyright David Grudl)
  *
- * Log all exceptions to <priority>.log
+ * Log all messages to <priority>.log
  *
  * @author Milan Felix Sulc <sulcmil@gmail.com>
  */

--- a/src/ILogger.php
+++ b/src/ILogger.php
@@ -19,8 +19,7 @@ interface ILogger
 
 	/**
 	 * @param mixed $message
-	 * @param string $priority
 	 */
-	public function log($message, $priority): void;
+	public function log($message, string $priority = ILogger::INFO): void;
 
 }

--- a/src/Mailer/FileMailer.php
+++ b/src/Mailer/FileMailer.php
@@ -2,9 +2,9 @@
 
 namespace Contributte\Logging\Mailer;
 
-use Contributte\Logging\Utils\Utils;
 use Exception;
 use Tracy\Helpers;
+use Tracy\Logger;
 
 /**
  * @author Milan Felix Sulc <sulcmil@gmail.com>
@@ -37,7 +37,7 @@ class FileMailer implements IMailer
 						'Content-Transfer-Encoding: 8bit',
 					]) . "\n",
 				'subject' => 'PHP: An error occurred on the server ' . $host,
-				'body' => Utils::formatMessage($message) . "\n\nsource: " . Helpers::getSource(),
+				'body' => Logger::formatMessage($message) . "\n\nsource: " . Helpers::getSource(),
 			]
 		);
 

--- a/src/Mailer/FileMailer.php
+++ b/src/Mailer/FileMailer.php
@@ -24,6 +24,7 @@ class FileMailer implements IMailer
 	 */
 	public function send($message): void
 	{
+		/** @var string $host */
 		$host = preg_replace('#[^\w.-]+#', '', $_SERVER['HTTP_HOST'] ?? php_uname('n'));
 		$parts = str_replace(
 			["\r\n", "\n"],

--- a/src/Mailer/FileMailer.php
+++ b/src/Mailer/FileMailer.php
@@ -2,7 +2,6 @@
 
 namespace Contributte\Logging\Mailer;
 
-use Exception;
 use Tracy\Helpers;
 use Tracy\Logger;
 
@@ -21,7 +20,7 @@ class FileMailer implements IMailer
 	}
 
 	/**
-	 * @param string|Exception $message
+	 * @param mixed $message
 	 */
 	public function send($message): void
 	{

--- a/src/Mailer/TracyMailer.php
+++ b/src/Mailer/TracyMailer.php
@@ -2,7 +2,6 @@
 
 namespace Contributte\Logging\Mailer;
 
-use Exception;
 use Tracy\Helpers;
 use Tracy\Logger;
 
@@ -30,7 +29,7 @@ class TracyMailer implements IMailer
 	}
 
 	/**
-	 * @param string|Exception $message
+	 * @param mixed $message
 	 */
 	public function send($message): void
 	{

--- a/src/Mailer/TracyMailer.php
+++ b/src/Mailer/TracyMailer.php
@@ -22,7 +22,7 @@ class TracyMailer implements IMailer
 	/**
 	 * @param mixed[] $to
 	 */
-	public function __construct(?string $from = NULL, array $to)
+	public function __construct(?string $from = null, array $to)
 	{
 		$this->from = $from;
 		$this->to = $to;
@@ -33,6 +33,7 @@ class TracyMailer implements IMailer
 	 */
 	public function send($message): void
 	{
+		/** @var string $host */
 		$host = preg_replace('#[^\w.-]+#', '', $_SERVER['HTTP_HOST'] ?? php_uname('n'));
 		$parts = str_replace(
 			["\r\n", "\n"],

--- a/src/Mailer/TracyMailer.php
+++ b/src/Mailer/TracyMailer.php
@@ -2,9 +2,9 @@
 
 namespace Contributte\Logging\Mailer;
 
-use Contributte\Logging\Utils\Utils;
 use Exception;
 use Tracy\Helpers;
+use Tracy\Logger;
 
 /**
  * TracyMailer based on official Tracy\Logger[default mailer] (@copyright David Grudl)
@@ -23,7 +23,7 @@ class TracyMailer implements IMailer
 	/**
 	 * @param mixed[] $to
 	 */
-	public function __construct(?string $from = null, array $to)
+	public function __construct(?string $from = NULL, array $to)
 	{
 		$this->from = $from;
 		$this->to = $to;
@@ -46,7 +46,7 @@ class TracyMailer implements IMailer
 						'Content-Transfer-Encoding: 8bit',
 					]) . "\n",
 				'subject' => 'PHP: An error occurred on the server ' . $host,
-				'body' => Utils::formatMessage($message) . "\n\nsource: " . Helpers::getSource(),
+				'body' => Logger::formatMessage($message) . "\n\nsource: " . Helpers::getSource(),
 			]
 		);
 

--- a/src/NullLogger.php
+++ b/src/NullLogger.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Logging;
+
+use Tracy\ILogger as TracyLogger;
+
+class NullLogger implements TracyLogger
+{
+
+	/**
+	 * @param mixed $message
+	 * @param string $priority
+	 */
+	public function log($message, $priority = self::INFO): void
+	{
+	}
+
+}

--- a/src/SendMailLogger.php
+++ b/src/SendMailLogger.php
@@ -3,7 +3,6 @@
 namespace Contributte\Logging;
 
 use Contributte\Logging\Mailer\IMailer;
-use Exception;
 
 class SendMailLogger extends AbstractLogger
 {
@@ -36,7 +35,6 @@ class SendMailLogger extends AbstractLogger
 	public function log($message, string $priority = ILogger::INFO): void
 	{
 		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], true)) return;
-		if (!($message instanceof Exception)) return;
 
 		$snooze = is_numeric($this->emailSnooze)
 			? $this->emailSnooze

--- a/src/SendMailLogger.php
+++ b/src/SendMailLogger.php
@@ -32,9 +32,8 @@ class SendMailLogger extends AbstractLogger
 
 	/**
 	 * @param mixed $message
-	 * @param string $priority
 	 */
-	public function log($message, $priority): void
+	public function log($message, string $priority = ILogger::INFO): void
 	{
 		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], true)) return;
 		if (!($message instanceof Exception)) return;

--- a/src/SendMailLogger.php
+++ b/src/SendMailLogger.php
@@ -15,10 +15,21 @@ class SendMailLogger extends AbstractLogger
 	/** @var IMailer */
 	private $mailer;
 
+	/** @var string[] */
+	private $allowedPriority = [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL];
+
 	public function __construct(IMailer $mailer, string $directory)
 	{
 		parent::__construct($directory);
 		$this->mailer = $mailer;
+	}
+
+	/**
+	 * @param string[] $allowedPriority
+	 */
+	public function setAllowedPriority(array $allowedPriority): void
+	{
+		$this->allowedPriority = $allowedPriority;
 	}
 
 	public function setEmailSnooze(string $emailSnooze): void
@@ -36,7 +47,7 @@ class SendMailLogger extends AbstractLogger
 	 */
 	public function log($message, string $priority = ILogger::INFO): void
 	{
-		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], true)) return;
+		if (!in_array($priority, $this->allowedPriority, true)) return;
 
 		if (is_numeric($this->emailSnooze)) {
 			$snooze = (int) $this->emailSnooze;

--- a/src/Sentry/SentryLogger.php
+++ b/src/Sentry/SentryLogger.php
@@ -3,7 +3,6 @@
 namespace Contributte\Logging\Sentry;
 
 use Contributte\Logging\ILogger;
-use Exception;
 use Raven_Client;
 use Throwable;
 
@@ -22,10 +21,9 @@ class SentryLogger implements ILogger
 	}
 
 	/**
-	 * @param string|Exception $message
-	 * @param string $priority
+	 * @param mixed $message
 	 */
-	public function log($message, $priority): void
+	public function log($message, string $priority = ILogger::INFO): void
 	{
 		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], true)) return;
 		if (!($message instanceof Throwable)) return;

--- a/src/Sentry/SentryLogger.php
+++ b/src/Sentry/SentryLogger.php
@@ -30,6 +30,7 @@ class SentryLogger implements ILogger
 		if (!isset($configuration['url'])) {
 			throw new InvalidStateException('Missing url in SentryLogger configuration');
 		}
+		$this->configuration = $configuration;
 	}
 
 	/**

--- a/src/Sentry/SentryLogger.php
+++ b/src/Sentry/SentryLogger.php
@@ -9,33 +9,67 @@ use Throwable;
 class SentryLogger implements ILogger
 {
 
-	/** @var mixed[] */
-	private $config;
+	public const LEVEL_PRIORITY_MAP = [
+		self::DEBUG => Raven_Client::DEBUG,
+		self::INFO => Raven_Client::INFO,
+		self::WARNING => Raven_Client::WARNING,
+		self::ERROR => Raven_Client::ERROR,
+		self::EXCEPTION => Raven_Client::FATAL,
+		self::CRITICAL => Raven_Client::FATAL,
+	];
+
+	/** @var string */
+	private $url;
 
 	/**
-	 * @param mixed[] $config
+	 * @param string $url
 	 */
-	public function __construct(array $config)
+	public function __construct(string $url)
 	{
-		$this->config = $config;
+		$this->url = $url;
 	}
 
 	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
 	 * @param mixed $message
 	 */
 	public function log($message, string $priority = ILogger::INFO): void
 	{
-		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], true)) return;
-		if (!($message instanceof Throwable)) return;
+		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], TRUE)) return;
 
-		// Send to Sentry
-		$this->makeRequest($message);
+		$level = $this->getLevel($priority);
+
+		if ($level === NULL) return;
+
+		$data = [
+			'level' => $level,
+		];
+
+		$this->makeRequest($message, $data);
 	}
 
-	protected function makeRequest(Throwable $message): void
+	/**
+	 * @param mixed $message
+	 * @param mixed[] $data
+	 */
+	protected function makeRequest($message, array $data): void
 	{
-		$client = new Raven_Client($this->config['url']);
-		$client->captureException($message);
+		$client = new Raven_Client($this->url);
+		if ($message instanceof Throwable) {
+			$client->captureException($message, $data);
+		} else {
+			$client->captureMessage($message, [], $data);
+		}
+	}
+
+	/**
+	 * @param string $priority
+	 * @return string|null
+	 */
+	protected function getLevel(string $priority): ?string
+	{
+		return self::LEVEL_PRIORITY_MAP[$priority] ?? NULL;
 	}
 
 }

--- a/src/Sentry/SentryLogger.php
+++ b/src/Sentry/SentryLogger.php
@@ -40,11 +40,11 @@ class SentryLogger implements ILogger
 	 */
 	public function log($message, string $priority = ILogger::INFO): void
 	{
-		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], TRUE)) return;
+		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], true)) return;
 
 		$level = $this->getLevel($priority);
 
-		if ($level === NULL) return;
+		if ($level === null) return;
 
 		$data = [
 			'level' => $level,
@@ -67,10 +67,6 @@ class SentryLogger implements ILogger
 		}
 	}
 
-	/**
-	 * @param string $priority
-	 * @return string|null
-	 */
 	protected function getLevel(string $priority): ?string
 	{
 		return self::LEVEL_PRIORITY_MAP[$priority] ?? null;

--- a/src/Sentry/SentryLogger.php
+++ b/src/Sentry/SentryLogger.php
@@ -2,6 +2,7 @@
 
 namespace Contributte\Logging\Sentry;
 
+use Contributte\Logging\Exceptions\Logical\InvalidStateException;
 use Contributte\Logging\ILogger;
 use Raven_Client;
 use Throwable;
@@ -18,15 +19,17 @@ class SentryLogger implements ILogger
 		self::CRITICAL => Raven_Client::FATAL,
 	];
 
-	/** @var string */
-	private $url;
+	/** @var mixed[] */
+	protected $configuration;
 
 	/**
-	 * @param string $url
+	 * @param mixed[] $configuration
 	 */
-	public function __construct(string $url)
+	public function __construct(array $configuration)
 	{
-		$this->url = $url;
+		if (!isset($configuration['url'])) {
+			throw new InvalidStateException('Missing url in SentryLogger configuration');
+		}
 	}
 
 	/**
@@ -55,7 +58,7 @@ class SentryLogger implements ILogger
 	 */
 	protected function makeRequest($message, array $data): void
 	{
-		$client = new Raven_Client($this->url);
+		$client = new Raven_Client($this->configuration['url']);
 		if ($message instanceof Throwable) {
 			$client->captureException($message, $data);
 		} else {
@@ -69,7 +72,7 @@ class SentryLogger implements ILogger
 	 */
 	protected function getLevel(string $priority): ?string
 	{
-		return self::LEVEL_PRIORITY_MAP[$priority] ?? NULL;
+		return self::LEVEL_PRIORITY_MAP[$priority] ?? null;
 	}
 
 }

--- a/src/Sentry/SentryLogger.php
+++ b/src/Sentry/SentryLogger.php
@@ -7,7 +7,7 @@ use Exception;
 use Raven_Client;
 use Throwable;
 
-final class SentryLogger implements ILogger
+class SentryLogger implements ILogger
 {
 
 	/** @var mixed[] */

--- a/src/Sentry/SentryLogger.php
+++ b/src/Sentry/SentryLogger.php
@@ -22,6 +22,9 @@ class SentryLogger implements ILogger
 	/** @var mixed[] */
 	protected $configuration;
 
+	/** @var string[] */
+	private $allowedPriority = [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL];
+
 	/**
 	 * @param mixed[] $configuration
 	 */
@@ -34,17 +37,28 @@ class SentryLogger implements ILogger
 	}
 
 	/**
+	 * @param string[] $allowedPriority
+	 */
+	public function setAllowedPriority(array $allowedPriority): void
+	{
+		$this->allowedPriority = $allowedPriority;
+	}
+
+	/**
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
 	 * @param mixed $message
 	 */
 	public function log($message, string $priority = ILogger::INFO): void
 	{
-		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], true)) return;
+		if (!in_array($priority, $this->allowedPriority, true)) {
+			return;
+		}
 
 		$level = $this->getLevel($priority);
-
-		if ($level === null) return;
+		if ($level === null) {
+			return;
+		}
 
 		$data = [
 			'level' => $level,

--- a/src/Slack/Formatter/ColorFormatter.php
+++ b/src/Slack/Formatter/ColorFormatter.php
@@ -12,7 +12,7 @@ final class ColorFormatter implements IFormatter
 {
 
 	/**
-	 * {@inheritdoc}
+	 * @param mixed $message
 	 */
 	public function format(SlackContext $context, $message, string $priority): SlackContext
 	{

--- a/src/Slack/Formatter/ContextFormatter.php
+++ b/src/Slack/Formatter/ContextFormatter.php
@@ -9,7 +9,7 @@ final class ContextFormatter implements IFormatter
 {
 
 	/**
-	 * {@inheritdoc}
+	 * @param mixed $message
 	 */
 	public function format(SlackContext $context, $message, string $priority): SlackContext
 	{

--- a/src/Slack/Formatter/ExceptionFormatter.php
+++ b/src/Slack/Formatter/ExceptionFormatter.php
@@ -11,7 +11,7 @@ final class ExceptionFormatter implements IFormatter
 {
 
 	/**
-	 * {@inheritdoc}
+	 * @param mixed $exception
 	 */
 	public function format(SlackContext $context, $exception, string $priority): SlackContext
 	{

--- a/src/Slack/Formatter/ExceptionPreviousExceptionsFormatter.php
+++ b/src/Slack/Formatter/ExceptionPreviousExceptionsFormatter.php
@@ -9,7 +9,7 @@ final class ExceptionPreviousExceptionsFormatter implements IFormatter
 {
 
 	/**
-	 * {@inheritdoc}
+	 * @param mixed $exception
 	 */
 	public function format(SlackContext $context, $exception, string $priority): SlackContext
 	{

--- a/src/Slack/Formatter/ExceptionStackTraceFormatter.php
+++ b/src/Slack/Formatter/ExceptionStackTraceFormatter.php
@@ -9,7 +9,7 @@ final class ExceptionStackTraceFormatter implements IFormatter
 {
 
 	/**
-	 * {@inheritdoc}
+	 * @param mixed $exception
 	 */
 	public function format(SlackContext $context, $exception, string $priority): SlackContext
 	{

--- a/src/Slack/Formatter/IFormatter.php
+++ b/src/Slack/Formatter/IFormatter.php
@@ -2,8 +2,6 @@
 
 namespace Contributte\Logging\Slack\Formatter;
 
-use Throwable;
-
 /**
  * @author Milan Felix Sulc <sulcmil@gmail.com>
  */
@@ -11,7 +9,7 @@ interface IFormatter
 {
 
 	/**
-	 * @param string|Throwable $message
+	 * @param mixed $message
 	 */
 	public function format(SlackContext $context, $message, string $priority): SlackContext;
 

--- a/src/Slack/Formatter/SlackContext.php
+++ b/src/Slack/Formatter/SlackContext.php
@@ -101,14 +101,14 @@ final class SlackContext
 	{
 		$data = $this->data;
 
-		if ($this->fields) {
+		if (count($this->fields) > 0) {
 			$data['fields'] = [];
 			foreach ($this->fields as $attachment) {
 				$data['fields'][] = $attachment->toArray();
 			}
 		}
 
-		if ($this->attachments) {
+		if (count($this->fields) > 0) {
 			$data['attachments'] = [];
 			foreach ($this->attachments as $attachment) {
 				$data['attachments'][] = $attachment->toArray();

--- a/src/Slack/Formatter/SlackContextAttachment.php
+++ b/src/Slack/Formatter/SlackContextAttachment.php
@@ -105,7 +105,7 @@ final class SlackContextAttachment
 	{
 		$data = $this->data;
 
-		if ($this->fields) {
+		if (count($this->fields) > 0) {
 			$data['fields'] = [];
 			foreach ($this->fields as $attachment) {
 				$data['fields'][] = $attachment->toArray();

--- a/src/Slack/SlackLogger.php
+++ b/src/Slack/SlackLogger.php
@@ -36,7 +36,6 @@ final class SlackLogger implements ILogger
 
 	/**
 	 * @param mixed $message
-	 * @param string $priority
 	 */
 	public function log($message, string $priority = ILogger::INFO): void
 	{

--- a/src/Slack/SlackLogger.php
+++ b/src/Slack/SlackLogger.php
@@ -6,7 +6,6 @@ use Contributte\Logging\Exceptions\Runtime\Logger\SlackBadRequestException;
 use Contributte\Logging\ILogger;
 use Contributte\Logging\Slack\Formatter\IFormatter;
 use Contributte\Logging\Slack\Formatter\SlackContext;
-use Exception;
 use Nette\Utils\Arrays;
 use Throwable;
 
@@ -36,13 +35,13 @@ final class SlackLogger implements ILogger
 	}
 
 	/**
-	 * @param string|Throwable $message
+	 * @param mixed $message
 	 * @param string $priority
 	 */
-	public function log($message, $priority): void
+	public function log($message, string $priority = ILogger::INFO): void
 	{
 		if (!in_array($priority, [ILogger::ERROR, ILogger::EXCEPTION, ILogger::CRITICAL], true)) return;
-		if (!($message instanceof Exception)) return;
+		if (!($message instanceof Throwable)) return;
 
 		$context = new SlackContext($this->config);
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -2,12 +2,8 @@
 
 namespace Contributte\Logging\Utils;
 
-use ErrorException;
-use Exception;
 use Throwable;
 use Tracy\BlueScreen;
-use Tracy\Dumper;
-use Tracy\Helpers;
 
 /**
  * Based on official Tracy\Logger (@copyright David Grudl)
@@ -16,43 +12,6 @@ use Tracy\Helpers;
  */
 final class Utils
 {
-
-	/**
-	 * @param string|Exception $message
-	 */
-	public static function formatMessage($message): string
-	{
-		if ($message instanceof Exception) {
-			$tmp = [];
-			while ($message) {
-				$tmp[] = ($message instanceof ErrorException
-						? Helpers::errorTypeToString($message->getSeverity()) . ': ' . $message->getMessage()
-						: Helpers::getClass($message) . ': ' . $message->getMessage() . ($message->getCode() ? ' #' . $message->getCode() : '')
-					) . ' in ' . $message->getFile() . ':' . $message->getLine();
-				$message = $message->getPrevious();
-			}
-			$message = implode("\ncaused by ", $tmp);
-
-		} elseif (!is_string($message)) {
-			$message = Dumper::toText($message);
-		}
-
-		return trim($message);
-	}
-
-	/**
-	 * @param string|Exception $message
-	 * @param string $exceptionFile
-	 */
-	public static function formatLogLine($message, $exceptionFile = null): string
-	{
-		return implode(' ', [
-			@date('[Y-m-d H-i-s]'), // @ timezone may not be set
-			preg_replace('#\s*\r?\n\s*#', ' ', self::formatMessage($message)),
-			' @  ' . Helpers::getSource(),
-			$exceptionFile ? ' @@  ' . basename($exceptionFile) : null,
-		]);
-	}
 
 	public static function dumpException(Throwable $exception, string $file, ?BlueScreen $blueScreen = null): string
 	{

--- a/tests/cases/Logger/ExceptionFileLogger.phpt
+++ b/tests/cases/Logger/ExceptionFileLogger.phpt
@@ -4,7 +4,7 @@
  * TEST: Logger\ExceptionFileLogger
  */
 
-use Contributte\Logging\ExceptionFileLogger;
+use Contributte\Logging\FileLogger;
 use Tester\Assert;
 
 require_once __DIR__ . '/../../bootstrap.php';
@@ -13,7 +13,7 @@ test(function (): void {
 	Assert::false(file_exists(TEMP_DIR . '/critical.log'));
 	$exception = new RuntimeException('Foobar', 100);
 
-	$logger = new ExceptionFileLogger(TEMP_DIR);
+	$logger = new FileLogger(TEMP_DIR);
 	$logger->log($exception, $logger::CRITICAL);
 	Assert::true(file_exists(TEMP_DIR . '/critical.log'));
 });

--- a/tests/cases/Logger/FileLogger.phpt
+++ b/tests/cases/Logger/FileLogger.phpt
@@ -1,7 +1,7 @@
 <?php declare(strict_types = 1);
 
 /**
- * TEST: Logger\ExceptionFileLogger
+ * TEST: Logger\FileLogger
  */
 
 use Contributte\Logging\FileLogger;

--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,8 +1,0 @@
-[PHP]
-;extension_dir = "./ext"
-extension=tokenizer.so
-;extension=json.so
-;extension=mcrypt.so
-
-[Zend]
-;zend_extension="./ext/zend_extension"


### PR DESCRIPTION
## New version

- lots of bc breaks (added typehints to interface)
- support only `2.5.x` tracy

### TracyLoggingExtension

- keep original Tracy Logger in DIC with different key `logging.originalLogger`

### SendMailLogger

- not filter only `Exception` [#22]
- sending also `string` messages with `critical`/`error`/`exception` priority (as in the original Logger)
- configurable priority

### SentryLogger
- removed `final`
- added priority level
- sending also `string` messages with `critical`/`error`/`exception` priority
- configurable priority

### FileLogger

- renamed from `ExceptionFileLogger` (because it does not log only exceptions but`<priority>.log`)

### NullLogger

- with Tracy/ILogger interface [#10]

### Utils 

- used static methods `formatLogLine`,`formatMessage` from original `Tracy\Logger`

------------------

### TODO 

- [ ] tag new version (bc breaks)