### PR TITLE
Fix SendMailLogger failing when email-sent file doesn't exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
       "Contributte\\Logging\\": "src"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\Helpers\\": "tests/helpers"
+    }
+  },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "extra": {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -10,7 +10,8 @@
         <properties>
             <property name="rootNamespaces" type="array" value="
                 src=>Contributte\Logging,
-                tests/fixtures=>Tests\Fixtures
+                tests/fixtures=>Tests\Fixtures,
+                tests/helpers=>Tests\Helpers
             "/>
         </properties>
     </rule>

--- a/src/SendMailLogger.php
+++ b/src/SendMailLogger.php
@@ -4,7 +4,6 @@ namespace Contributte\Logging;
 
 use Contributte\Logging\Mailer\IMailer;
 use Nette\InvalidArgumentException;
-use Nette\InvalidStateException;
 
 class SendMailLogger extends AbstractLogger
 {
@@ -66,7 +65,7 @@ class SendMailLogger extends AbstractLogger
 		$filemtime = @filemtime($this->directory . '/email-sent');
 
 		if ($filemtime === false) {
-			throw new InvalidStateException('File time cant be reached');
+			$filemtime = 0;
 		}
 
 		if ($filemtime + $snooze < time() && (bool) @file_put_contents($this->directory . '/email-sent', 'sent')

--- a/tests/cases/Logger/SendMailLogger.phpt
+++ b/tests/cases/Logger/SendMailLogger.phpt
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+/**
+ * TEST: Logger\SendMailLogger
+ */
+
+use Contributte\Logging\SendMailLogger;
+use Tester\Assert;
+use Tests\Helpers\TestMailer;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+test(function (): void {
+	// mailer should be called only once for default emailSnooze
+	@unlink(TEMP_DIR . '/email-sent');
+	$exception = new RuntimeException('Foobar', 100);
+	$mailer = new TestMailer();
+	$logger = new SendMailLogger($mailer, TEMP_DIR);
+
+	$logger->log($exception, $logger::CRITICAL);
+	$logger->log($exception, $logger::CRITICAL);
+
+	Assert::count(1, $mailer->messages);
+});
+
+test(function (): void {
+	// mailer should be called multiple times for negative emailSnooze
+	@unlink(TEMP_DIR . '/email-sent');
+	$exception = new RuntimeException('Foobar', 100);
+	$mailer = new TestMailer();
+	$logger = new SendMailLogger($mailer, TEMP_DIR);
+	$logger->setEmailSnooze('-1');
+
+	$logger->log($exception, $logger::CRITICAL);
+	$logger->log($exception, $logger::CRITICAL);
+
+	Assert::count(2, $mailer->messages);
+});

--- a/tests/helpers/TestMailer.php
+++ b/tests/helpers/TestMailer.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Helpers;
+
+use Contributte\Logging\Mailer\IMailer;
+
+class TestMailer implements IMailer
+{
+
+	/** @var mixed[] */
+	public $messages = [];
+
+	/**
+	 * @param mixed $message
+	 */
+	public function send($message): void
+	{
+		$this->messages[] = $message;
+	}
+
+}


### PR DESCRIPTION
When the file didn't exist (e.g. after a new install/deploy) the mailer would throw an exception and the app would crash.

Also added some tests.